### PR TITLE
Fix for spaces within java path

### DIFF
--- a/scripts/image2c.bat
+++ b/scripts/image2c.bat
@@ -1,2 +1,2 @@
 @echo off
-start "" /min %JAVA_HOME%\bin\javaw -jar guislice_image2c-1.04.jar
+start "" /min "%JAVA_HOME%\bin\javaw" -jar guislice_image2c-1.04.jar


### PR DESCRIPTION
- A common default for JAVA_HOME might be "C:\Program Files (x86)\Arduino\java"
- Without this fix, the content after the space in "Program" is interpreted as additional arguments